### PR TITLE
Fix variable bug in wallpaper_cava

### DIFF
--- a/scripts/wallpaper_cava
+++ b/scripts/wallpaper_cava
@@ -16,5 +16,5 @@ xprop -id "$WIN_ID" -f _NET_WM_WINDOW_TYPE 32a -set _NET_WM_WINDOW_TYPE _NET_WM_
 wmctrl -i -r "$WIN_ID" -b add,below,sticky,skip_taskbar,skip_pager
 
 # Pierde el foco automáticamente
-xdotool windowunfocus "$win_id"
-xdotool windowminimize "$win_id"
+xdotool windowunfocus "$WIN_ID"
+xdotool windowminimize "$WIN_ID"


### PR DESCRIPTION
## Summary
- fix incorrect variable reference in `wallpaper_cava`

## Testing
- `shellcheck scripts/wallpaper_cava` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b756b808323be78ccfe60c66fb7