### PR TITLE
Centralizar definición de mod en configuración de Qtile

### DIFF
--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -1,3 +1,5 @@
+mod = "mod4"
+
 from libqtile import hook
 import hooks
 from keys import keys
@@ -8,8 +10,6 @@ from screens import screens
 from mouse import mouse
 from floating import floating_layout
 from autostart import autostart
-
-mod = "mod4"
 
 @hook.subscribe.startup_once
 def start_once():

--- a/.config/qtile/keys.py
+++ b/.config/qtile/keys.py
@@ -2,8 +2,7 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from bar_toggle import toggle_bar
 from groups import groups
-
-mod = "mod4"
+from config import mod
 terminal = "kitty"
 menu_manager = "rofi -show drun"
 browser = "firefox"

--- a/.config/qtile/mouse.py
+++ b/.config/qtile/mouse.py
@@ -1,7 +1,6 @@
 from libqtile.config import Drag, Click
 from libqtile.lazy import lazy
-
-mod = "mod4"
+from config import mod
 
 mouse = [
     Drag([mod], "Button1", lazy.window.set_position_floating(), start=lazy.window.get_position()),


### PR DESCRIPTION
## Summary
- Centraliza la definición de `mod` en `config.py` y la reutiliza en `keys.py` y `mouse.py`

## Testing
- `python -m py_compile .config/qtile/config.py .config/qtile/keys.py .config/qtile/mouse.py`


------
https://chatgpt.com/codex/tasks/task_e_6893a41019b88323bcc9556b6407e477