### PR TITLE
qtile: use theme colors for layouts

### DIFF
--- a/.config/qtile/layouts.py
+++ b/.config/qtile/layouts.py
@@ -1,9 +1,29 @@
 from libqtile import layout
+from theme import colors
 
 layouts = [
-    layout.MonadTall(margin=10, border_width=2, border_focus="#d79921", border_normal="#282828"),
-    layout.MonadWide(margin=10, border_width=2, border_focus="#d79921", border_normal="#282828"),
-    layout.Floating(border_width=2, border_focus="#d79921", border_normal="#282828"),
-    layout.Columns(border_focus_stack=["#d75f5f", "#8f3d3d"], border_width=4),
+    layout.MonadTall(
+        margin=10,
+        border_width=2,
+        border_focus=colors["border"],
+        border_normal=colors["background"],
+    ),
+    layout.MonadWide(
+        margin=10,
+        border_width=2,
+        border_focus=colors["border"],
+        border_normal=colors["background"],
+    ),
+    layout.Floating(
+        border_width=2,
+        border_focus=colors["border"],
+        border_normal=colors["background"],
+    ),
+    layout.Columns(
+        border_width=4,
+        border_focus=colors["border"],
+        border_normal=colors["background"],
+        border_focus_stack=[colors["border"], colors["background"]],
+    ),
     layout.Max(),
 ]


### PR DESCRIPTION
## Summary
- import theme colors in qtile layouts
- replace hard-coded border/background colors with theme references
- ensure consistent border settings across layouts

## Testing
- `python -m py_compile .config/qtile/layouts.py .config/qtile/theme.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c190cc988323b0d96d28995e059c