### PR TITLE
Use theme font and bar size

### DIFF
--- a/.config/qtile/screens.py
+++ b/.config/qtile/screens.py
@@ -1,11 +1,11 @@
 from libqtile.config import Screen
 from widgets import widgets
 from libqtile import bar
-from theme import colors
+from theme import colors, bar_size
 
 show_bar = True  # Esta variable puede ser modificada dinámicamente
 
 if show_bar:
-    screens = [Screen(bottom=bar.Bar(widgets, 26, background=colors["background"]))]
+    screens = [Screen(bottom=bar.Bar(widgets, bar_size, background=colors["background"]))]
 else:
     screens = [Screen()]

--- a/.config/qtile/widgets.py
+++ b/.config/qtile/widgets.py
@@ -1,10 +1,10 @@
 from libqtile import widget
 from libqtile import qtile
-from theme import colors, font, font_size, bar_size
+from theme import colors, font, font_size
 
 widget_defaults = dict(
-    font="CaskaydiaMono Nerd Font",
-    fontsize=14,
+    font=font,
+    fontsize=font_size,
     padding=5,
 )
 


### PR DESCRIPTION
## Summary
- rely on theme font and size for widget defaults
- apply theme bar_size to screen configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893d07772ac8323a31ebe1bfc708640