### PR TITLE
Unify bar visibility management in Qtile config

### DIFF
--- a/.config/qtile/bar_toggle.py
+++ b/.config/qtile/bar_toggle.py
@@ -1,16 +1,35 @@
+"""Utilities to toggle the visibility of Qtile bars.
+
+`bar_states` stores the current visibility of each screen's bar. The
+`DEFAULT_BAR_VISIBILITY` flag defines the initial visibility for any screen
+that does not yet have an entry in ``bar_states``.
+"""
+
 from libqtile import qtile
 
-bar_states = {}
+# Default visibility for newly discovered bars. ``True`` means the bar starts
+# visible.
+DEFAULT_BAR_VISIBILITY = True
 
-def toggle_bar(qtile):
+# Keeps track of the visibility state of each bar. Keys are screen indexes and
+# values are booleans indicating whether the bar is currently visible.
+bar_states: dict[int, bool] = {}
+
+
+def toggle_bar(qtile) -> None:
+    """Toggle the visibility of bars on all screens.
+
+    The function respects the initial value stored in ``bar_states`` or falls
+    back to ``DEFAULT_BAR_VISIBILITY`` when a screen is toggled for the first
+    time.
+    """
+
     for i, screen in enumerate(qtile.screens):
         bar = screen.bottom
-        if i not in bar_states:
-            bar_states[i] = True  # Por defecto la barra está visible
+        visible = bar_states.get(i, DEFAULT_BAR_VISIBILITY)
 
-        if bar_states[i]:
-            bar.show(False)
-        else:
-            bar.show(True)
+        # Show the bar if it is currently hidden and vice versa.
+        bar.show(not visible)
 
-        bar_states[i] = not bar_states[i]
+        # Store the updated visibility state.
+        bar_states[i] = not visible

--- a/.config/qtile/screens.py
+++ b/.config/qtile/screens.py
@@ -2,10 +2,14 @@ from libqtile.config import Screen
 from widgets import widgets
 from libqtile import bar
 from theme import colors, bar_size
+from bar_toggle import DEFAULT_BAR_VISIBILITY, bar_states
 
-show_bar = True  # Esta variable puede ser modificada dinámicamente
+# Create a screen with a bottom bar and initialise its visibility according to
+# the global state stored in ``bar_states``. The same approach can be extended to
+# multiple screens if needed.
+screens = [Screen(bottom=bar.Bar(widgets, bar_size, background=colors["background"]))]
 
-if show_bar:
-    screens = [Screen(bottom=bar.Bar(widgets, bar_size, background=colors["background"]))]
-else:
-    screens = [Screen()]
+for i, screen in enumerate(screens):
+    bar_states.setdefault(i, DEFAULT_BAR_VISIBILITY)
+    if not bar_states[i]:
+        screen.bottom.show(False)


### PR DESCRIPTION
## Summary
- centralize bar visibility using `bar_states` and `DEFAULT_BAR_VISIBILITY`
- remove `show_bar` flag from screen configuration
- ensure bar toggling respects initial visibility state

## Testing
- `python -m py_compile .config/qtile/bar_toggle.py .config/qtile/screens.py`


------
https://chatgpt.com/codex/tasks/task_e_6896429d744483238fccb8fcd95fb92d