### PR TITLE
Refine floating window management in Qtile config

### DIFF
--- a/.config/qtile/floating.py
+++ b/.config/qtile/floating.py
@@ -1,7 +1,11 @@
 from libqtile.config import Match
 from libqtile import layout
+from theme import colors
 
 floating_layout = layout.Floating(
+    border_width=2,
+    border_focus=colors["border"],
+    border_normal=colors["background"],
     float_rules=[
         *layout.Floating.default_float_rules,
         Match(wm_class="confirmreset"),

--- a/.config/qtile/layouts.py
+++ b/.config/qtile/layouts.py
@@ -14,11 +14,6 @@ layouts = [
         border_focus=colors["border"],
         border_normal=colors["background"],
     ),
-    layout.Floating(
-        border_width=2,
-        border_focus=colors["border"],
-        border_normal=colors["background"],
-    ),
     layout.Columns(
         border_width=4,
         border_focus=colors["border"],


### PR DESCRIPTION
## Summary
- remove `layout.Floating` from selectable layouts
- style `floating_layout` with theme colors and borders

## Testing
- `python -m py_compile .config/qtile/layouts.py .config/qtile/floating.py`


------
https://chatgpt.com/codex/tasks/task_e_68964eb5a27483239f1511db864fbacb